### PR TITLE
Implement WebsiteScraper with bs4

### DIFF
--- a/requirements
+++ b/requirements
@@ -1,2 +1,4 @@
 this is the list of requiremets:
 - nothing
+- requests
+- beautifulsoup4

--- a/test_website_scraper.py
+++ b/test_website_scraper.py
@@ -1,0 +1,27 @@
+import types
+from unittest import mock
+
+import requests
+from bs4 import BeautifulSoup
+
+from website_scraper import WebsiteScraper
+
+
+class MockResponse:
+    def __init__(self, text: str, status_code: int = 200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if not (200 <= self.status_code < 300):
+            raise requests.HTTPError(f"Status {self.status_code}")
+
+
+def test_fetch_title_and_content():
+    html = "<html><head><title>Test</title></head><body><p>Hello</p></body></html>"
+    mock_resp = MockResponse(html)
+    with mock.patch("requests.get", return_value=mock_resp):
+        scraper = WebsiteScraper("http://example.com")
+        content, title = scraper.fetch()
+        assert title == "Test"
+        assert "Hello" in content

--- a/website_scraper.py
+++ b/website_scraper.py
@@ -1,0 +1,19 @@
+from typing import Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+
+class WebsiteScraper:
+    """Simple scraper that returns the page content and title for a given URL."""
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    def fetch(self) -> Tuple[str, str]:
+        """Fetch the URL and return a tuple of (content, title)."""
+        response = requests.get(self.url)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'html.parser')
+        title = soup.title.string.strip() if soup.title and soup.title.string else ''
+        content = soup.get_text(separator='\n')
+        return content, title


### PR DESCRIPTION
## Summary
- add `WebsiteScraper` class that fetches a page and returns its text and title
- document new dependencies
- include unit test for scraper using mocked requests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6866e870ca2c832ba2eb649472654078