### PR TITLE
Fix scraper design and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Website Scraper
+
+This project provides a small `WebsiteScraper` class for retrieving web page content and titles using `requests` and `BeautifulSoup`.
+
+## Installation
+
+Install dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+Tests are written with `pytest`.
+
+```bash
+pytest
+```
+
+## Usage Example
+
+```python
+from website_scraper import WebsiteScraper
+
+scraper = WebsiteScraper("https://example.com")
+print(scraper.title)
+print(scraper.content)
+```

--- a/requirements
+++ b/requirements
@@ -1,4 +1,0 @@
-this is the list of requiremets:
-- nothing
-- requests
-- beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/test1.py
+++ b/test1.py
@@ -4,11 +4,11 @@ def sum(a: int, b: int, c: int):
 
 def test():
     "test 1"
-    raise NotImplemented()
+    raise NotImplementedError()
 
 
 def test2():
-    raise NotImplemented()
+    raise NotImplementedError()
 
 
 def _test():

--- a/test_website_scraper.py
+++ b/test_website_scraper.py
@@ -1,8 +1,6 @@
-import types
 from unittest import mock
 
 import requests
-from bs4 import BeautifulSoup
 
 from website_scraper import WebsiteScraper
 

--- a/website_scraper.py
+++ b/website_scraper.py
@@ -8,12 +8,20 @@ class WebsiteScraper:
     """Simple scraper that returns the page content and title for a given URL."""
     def __init__(self, url: str) -> None:
         self.url = url
+        self.content = ""
+        self.title = ""
+        self._fetch()
 
-    def fetch(self) -> Tuple[str, str]:
-        """Fetch the URL and return a tuple of (content, title)."""
+    def _fetch(self) -> None:
+        """Retrieve the page and store the cleaned content and title."""
         response = requests.get(self.url)
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, 'html.parser')
-        title = soup.title.string.strip() if soup.title and soup.title.string else ''
-        content = soup.get_text(separator='\n')
-        return content, title
+        soup = BeautifulSoup(response.text, "html.parser")
+        self.title = (
+            soup.title.string.strip() if soup.title and soup.title.string else ""
+        )
+        self.content = soup.get_text(separator="\n").strip()
+
+    def fetch(self) -> Tuple[str, str]:
+        """Return the content and title previously fetched."""
+        return self.content, self.title


### PR DESCRIPTION
## Summary
- rename `requirements` to `requirements.txt`
- collect content and title during scraper init
- clean up stray quote and extra imports
- fix placeholder tests
- add initial README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6866f1e7ae68832bb35ae3ad1c286eeb